### PR TITLE
fix #9

### DIFF
--- a/mdcal.py
+++ b/mdcal.py
@@ -88,14 +88,17 @@ def update_calendar(year, month, day, with_isoweek=False, start_from_Sun=False, 
         calendar_section_lines += calendar_section.split("\n")[2:]
     
     star_flag = True
-    for i in range(len(calendar_section_lines) - 1, 3, -1):
+    month_start_flag = False
+    for i in range(4, len(calendar_section_lines)):
         if re.match("^\\|([ ]*.*[ ]*\|)+$", calendar_section_lines[i]):
             day_cells = calendar_section_lines[i].split("|")
-            for j in range(len(day_cells) - 2, 0, -1):
+            for j in range(1, len(day_cells) - 1):
                 digit = re.findall(r'\d+', day_cells[j].strip())
                 if len(digit) == 0:
                     continue
-                if digit[0] == str(day) and "🌟" not in day_cells[j] and star_flag:
+                if digit[0] == "1":
+                    month_start_flag = True   
+                if digit[0] == str(day) and "🌟" not in day_cells[j] and star_flag and month_start_flag:
                     day_cells[j] = day_cells[j].strip() + "🌟"
                     star_flag = False
             calendar_section_lines[i] = "|".join(day_cells)


### PR DESCRIPTION
发现昨天使用的：倒序遍历打星号，从而修复把星号打在上个月的issue 有问题-这种方法会出现把星号打在下个月的日期的问题（比如2024年1月1日的会被打在2024年2月1日上>_<)所以重新修复了一下：仍然正序遍历日期，同时用month_start_flag标识是否已经找到了当月的开始日期（即X月1日），只有在已经找到了当月开始日期时，才对第一个符合的日期打星号。