### PR TITLE
fix marking star on a second date when you submit issues in the same day

### DIFF
--- a/mdcal.py
+++ b/mdcal.py
@@ -88,6 +88,7 @@ def update_calendar(year, month, day, with_isoweek=False, start_from_Sun=False, 
         calendar_section_lines += calendar_section.split("\n")[2:]
     
     star_flag = True
+    # Indicate whether we have entered the part of the calendar that really belongs to the current month
     month_start_flag = False
     for i in range(4, len(calendar_section_lines)):
         if re.match("^\\|([ ]*.*[ ]*\|)+$", calendar_section_lines[i]):
@@ -97,11 +98,17 @@ def update_calendar(year, month, day, with_isoweek=False, start_from_Sun=False, 
                 if len(digit) == 0:
                     continue
                 if digit[0] == "1":
-                    month_start_flag = True   
-                if digit[0] == str(day) and "🌟" not in day_cells[j] and star_flag and month_start_flag:
-                    day_cells[j] = day_cells[j].strip() + "🌟"
+                    month_start_flag = True
+                # Current day_cell has the same day and month as our target date. It's where we want to mark a star      
+                if digit[0] == str(day) and month_start_flag:
+                    if "🌟" not in day_cells[j]:
+                        day_cells[j] = day_cells[j].strip() + "🌟"
+                    # Change flag to show that star has been marked - either by appending a star to the original text or doing nothing since there is already a star   
                     star_flag = False
+                    break    
             calendar_section_lines[i] = "|".join(day_cells)
+        if not star_flag:
+            break
 
     # Replace 'Calendar' section in README.md with the updated section
     new_content = re.sub(r"## 🎯 Calendar(.*)(?=## 🍃 Records)", "\n".join(calendar_section_lines), content, flags=re.DOTALL)


### PR DESCRIPTION
之前的代码在同时满足下面条件：
1.当前cell日期是m月d日 或者 (m + 1)月d日
2.当前cell没星号
3.本次update calendar还未完成打星号任务(star_flag = true）
时才会对当前cell打星号并且标记star_flag为true。
会出现一天内提交2次issue时，m月d日由于已经标记过一次星号，不满足条件2，被筛过，最终选择(m+1)月d日进行星号标记的问题。（比如2024年1月2日提交2次issue, 会对2024年1月2日和2月2日分别标星号)
本pr进行了一下修复，不将条件2用于判断是否要为当前cell打星号，而是仅将其用于决策如何为当前cell打星号-如果无星号，append星号, 否则保持cell原内容。